### PR TITLE
ci(solium): exclude no-block-members rule

### DIFF
--- a/.soliumrc.js
+++ b/.soliumrc.js
@@ -3,6 +3,7 @@ module.exports = {
   plugins: ['security'],
   rules: {
     quotes: ['error', 'double'],
-    indentation: ['error', 4]
+    indentation: ['error', 4],
+    'security/no-block-members': ['off']
   }
 }


### PR DESCRIPTION
We always use block members so I thought it's easier to exclude the rule instead of adding `// solium-disable-next-line security/no-block-members` to source code.