### PR TITLE
ci(solium): require error-reason severity increase

### DIFF
--- a/.soliumrc.js
+++ b/.soliumrc.js
@@ -4,6 +4,7 @@ module.exports = {
   rules: {
     quotes: ['error', 'double'],
     indentation: ['error', 4],
-    'security/no-block-members': ['off']
+    'security/no-block-members': ['off'],
+    'error-reason': ['error']
   }
 }

--- a/.soliumrc.js
+++ b/.soliumrc.js
@@ -4,7 +4,7 @@ module.exports = {
   rules: {
     quotes: ['error', 'double'],
     indentation: ['error', 4],
-    'security/no-block-members': ['off'],
-    'error-reason': ['error']
+    'error-reason': ['error'],
+    'security/no-block-members': ['off']
   }
 }


### PR DESCRIPTION
makes Solium to throw an error when a require statement is missing error reason argument