### PR TITLE
refactor(index): run test:truffle instead of test

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ switch (scriptName) {
     } finally {
       runCommand('git', ['stash', 'pop'], { resolveCommand: false })
     }
-    runCommand('yarn', ['test'], { resolveCommand: false })
+    runCommand('yarn', ['test:truffle'], { resolveCommand: false })
     break
   case 'cz':
     process.argv = []


### PR DESCRIPTION
During pre-commit, run test:truffle instead of test, to avoid coverage report.